### PR TITLE
Add Docker build and publish on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: [ "*.*.*" ]
   pull_request:
+    branches: [ "*" ]
 
 jobs:
   build:
@@ -22,3 +24,17 @@ jobs:
         run: mix test
       - name: Run Dialyzer
         run: mix dialyzer --format github
+      - name: Build Docker image
+        run: docker build -t docspec-api .
+      - name: Publish Docker image
+        if: startsWith(github.ref, 'refs/tags/') && github.ref_name =~ '^\d+\.\d+\.\d+$'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
+          IMAGE='ghcr.io/${{ github.repository }}:${{ github.ref_name }}'
+          docker tag docspec-api "$IMAGE"
+          docker push "$IMAGE"
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/') && github.ref_name =~ '^\d+\.\d+\.\d+$'
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- build docker image at the end of CI
- when CI runs for a Git tag like `x.y.z`, create a GitHub release and push the image to GHCR

## Testing
- `mix format --check-formatted` *(fails: mix not found)*
- `mix test` *(fails: mix not found)*
- `mix dialyzer --format github` *(fails: mix not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685d74a9357483218235f60ea526603d