### PR TITLE
Remove non-root user configuration that caused Kubernetes issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,10 @@ FROM elixir:1.19-alpine
 
 ENV MIX_ENV=prod
 
-RUN addgroup -g 1000 appgroup && \
-    adduser -u 1000 -G appgroup -s /bin/sh -D appuser
-
-WORKDIR /usr/src/app
-
-COPY --from=build --chown=appuser:appgroup /usr/src/app /usr/src/app
+COPY --from=build /usr/src/app /usr/src/app
 
 EXPOSE 4000
 
-USER appuser
+WORKDIR /usr/src/app
 
 CMD ["_build/prod/rel/docspec_api/bin/docspec_api", "start"]


### PR DESCRIPTION
The non-root user setup with custom UID/GID and chown operations was causing problems in Kubernetes environments. Reverting to root user simplifies the container configuration while maintaining functionality.