### PR TITLE
fix: run container as non-root user for Kubernetes compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,17 @@ FROM elixir:1.19-alpine
 
 ENV MIX_ENV=prod
 
-COPY --from=build /usr/src/app /usr/src/app
+# Create non-root user
+RUN addgroup -g 1000 appgroup && \
+    adduser -u 1000 -G appgroup -D appuser
+
+COPY --from=build --chown=appuser:appgroup /usr/src/app /usr/src/app
 
 EXPOSE 4000
 
 WORKDIR /usr/src/app
+
+# Run as non-root user (use numeric UID for Kubernetes runAsNonRoot verification)
+USER 1000
 
 CMD ["_build/prod/rel/docspec_api/bin/docspec_api", "start"]


### PR DESCRIPTION
Creates a non-root user and sets proper file ownership, then runs the container under that user. This ensures Kubernetes' runAsNonRoot security policy is satisfied and improves container security posture.